### PR TITLE
solves: ignore capital letters in the "classes filter" search text field. #10

### DIFF
--- a/src/main/java/clsvis/gui/MainFrame.java
+++ b/src/main/java/clsvis/gui/MainFrame.java
@@ -965,7 +965,26 @@ public class MainFrame extends JFrame {
 
         @Override
         public boolean include(Entry<? extends ClassesTableModel, ? extends Integer> entry) {
-            return entry.getModel().getRow(entry.getIdentifier()).fullTypeName.contains(filter);
+            return containsIgnoreCase(entry.getModel().getRow(entry.getIdentifier()).fullTypeName, filter);
+        }
+
+        private boolean containsIgnoreCase(String fullTypeName, String filter) {
+            if (filter.isEmpty()) return true;
+            if (fullTypeName.length() < filter.length()) return false;
+
+            int j = 0; // filter index
+            for (int i = 0; i < fullTypeName.length(); i++) {
+                if (Character.toLowerCase(fullTypeName.charAt(i)) ==
+                        Character.toLowerCase(filter.charAt(j))) {
+                    j++;
+                    if (j == filter.length()) return true;
+                } else if (j > 0) {
+                    // Backtrack: restart matching from current position
+                    i = i - j; // will be incremented by loop
+                    j = 0;
+                }
+            }
+            return false;
         }
     } //class
 


### PR DESCRIPTION
This commit solves issue #10. 

Enhanced class filter now supports matching just characters instead of substring.
Updated ```MainFrame.java``` class specifically static inner class ```ClassesTableRowFilter``` which now includes new private method to check if first string contains second by ignoring case. Also updated ```include``` method to use this new ```containsIgnoreCase``` method properly. There could also be better algorithms for implementing this new method, but actually since class names are not that long I think this will work just fine.



